### PR TITLE
Fix repo metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Bytes::Random::Secure::Tiny
 
+1.006 2015-07-??
+  - Fixed the META_MERGE entry in Makefile.PL - the 'meta-spec' part was
+    in the wrong place, so the repo wasn't appearing in the metadata.
+
 1.005 2015-07-05
   - Fixed a mistake in the SYNOPSIS. Improved description of string_from.
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Bytes::Random::Secure::Tiny
 1.006 2015-07-??
   - Fixed the META_MERGE entry in Makefile.PL - the 'meta-spec' part was
     in the wrong place, so the repo wasn't appearing in the metadata.
+  - The ABSTRACT_FROM was referring to the .pm file rather than the .pod
 
 1.005 2015-07-05
   - Fixed a mistake in the SYNOPSIS. Improved description of string_from.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,11 +22,11 @@ WriteMakefile(
     MIN_PERL_VERSION   => '5.008000',
     PREREQ_PM          => \%PREREQ_PM,
     META_MERGE => {
+      'meta-spec' => {version => 2},
       'resources' => {
-        'meta-spec' => {version => 2},
         'repository' => {
           'url'  => 'git://github.com/daoswald/Bytes-Random-Secure-Tiny.git',
-          'web'  => 'http://github.com/daoswald/Bytes-Random-Secure-Tiny',
+          'web'  => 'https://github.com/daoswald/Bytes-Random-Secure-Tiny',
           'type' => 'git',
         },
       },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
     NAME               => 'Bytes::Random::Secure::Tiny',
     AUTHOR             => q{David Oswald <davido@cpan.org>},
     VERSION_FROM       => 'lib/Bytes/Random/Secure/Tiny.pm',
-    ABSTRACT_FROM      => 'lib/Bytes/Random/Secure/Tiny.pm',
+    ABSTRACT_FROM      => 'lib/Bytes/Random/Secure/Tiny.pod',
     ($ExtUtils::MakeMaker::VERSION >= 6.3002 ? ('LICENSE' => 'perl') : ()),
     PL_FILES           => {},
     CONFIGURE_REQUIRES => {'ExtUtils::MakeMaker' => '6.56'},

--- a/lib/Bytes/Random/Secure/Tiny.pm
+++ b/lib/Bytes/Random/Secure/Tiny.pm
@@ -14,7 +14,7 @@ use Carp qw/croak/;
 
 ## no critic (constant)
 
-our $VERSION = '1.005';
+our $VERSION = '1.006';
 use constant UINT32_SIZE => 4;
 
 sub new {


### PR DESCRIPTION
Hi David,

The 'meta-spec' entry in `META_MERGE` was at the wrong level, so as a result the repo wasn't appearing in `META.{yml,json}`. This fixes that.

While doing that I noticed that the `ABSTRACT_FROM` was pointing to the `.pm` file rather than the `.pod`, resulting in a warning when you run `make dist`.

Cheers,
Neil
